### PR TITLE
Arreglo en método delete, eliminación de payload no definido.

### DIFF
--- a/lib/centry.rb
+++ b/lib/centry.rb
@@ -150,7 +150,7 @@ class Centry
   # @param [Hash] params (opcional) Llaves y valores que irán en la URL como
   # parámetros GET
   def delete(endpoint, params = {})
-    request(endpoint, :delete, params, payload)
+    request(endpoint, :delete, params)
   end
 
   # Una vez que un usuario ha autorizado nuestra aplicación para que accceda a


### PR DESCRIPTION
Arreglo de método _delete_ que enviaba un parámetro _payload_, que no estaba definido, al request interno.
